### PR TITLE
[TRNT-4358] Add license headers

### DIFF
--- a/.github/workflows/demo-idp.yaml
+++ b/.github/workflows/demo-idp.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Demo IDP CI/CD
 
 on:

--- a/.github/workflows/egeria-deploy.yaml
+++ b/.github/workflows/egeria-deploy.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Deploy Egeria Rolling version on PR env machine
 on:
   workflow_dispatch:

--- a/.github/workflows/egeria.yml
+++ b/.github/workflows/egeria.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 name: Egeria CI/CD
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Created by https://www.toptal.com/developers/gitignore/api/python,ansible,vagrant
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,ansible,vagrant
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,13 +12,10 @@ header:
       SPDX-License-Identifier: Apache-2.0
   paths-ignore:
     - "**/*.adoc"
-    - "**/*.example"
     - "**/*.json"
     - "**/*.md"
-    - "**/*.pem"
     - "**/*.service"
     - "**/*.svg"
-    - "**/*.txt"
     - "**/*_service"
     - ".ansible-lint"
     - ".github/CODEOWNERS"
@@ -26,7 +23,6 @@ header:
     - ".tool-versions"
     - ".yamllint"
     - "LICENSE"
-    - "VERSION"
     - "egeria/go.sum"
 
   language:

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -6,7 +6,7 @@ header:
   license:
     spdx-id: Apache-2.0
     copyright-owner: SUSE LLC
-    software-name: mcp-server-trento
+    software-name: trento-werkzeugkoffer
     content: |
       SPDX-FileCopyrightText: SUSE LLC
       SPDX-License-Identifier: Apache-2.0

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: mcp-server-trento
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - "**/*.example"
+    - "**/*.json"
+    - "**/*.md"
+    - "**/*.pem"
+    - "**/*.service"
+    - "**/*.svg"
+    - "**/*.txt"
+    - "**/*_service"
+    - ".ansible-lint"
+    - ".github/CODEOWNERS"
+    - ".github/dependabot.yml"
+    - ".tool-versions"
+    - ".yamllint"
+    - "LICENSE"
+    - "VERSION"
+    - "egeria/go.sum"
+
+  language:
+    JavaScript:
+      extensions:
+        - ".js"
+        - ".jsx"
+        - ".mjs"
+        - ".cjs"
+      comment_style_id: DoubleSlash

--- a/demo-idp/docker/Dockerfile
+++ b/demo-idp/docker/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 FROM opensuse/leap:15
 LABEL org.opencontainers.image.source="https://github.com/trento-project/werkzeugkoffer"
 LABEL org.opencontainers.image.authors="Carmine Di Monaco <carmine.dimonaco@suse.com>"

--- a/demo-idp/docker/entrypoint.sh
+++ b/demo-idp/docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 
 usage() {

--- a/demo-idp/group_vars/all.yml
+++ b/demo-idp/group_vars/all.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 postgres_keycloak_db: keycloak
 postgres_keycloak_user: keycloak

--- a/demo-idp/group_vars/keycloak-server.yml
+++ b/demo-idp/group_vars/keycloak-server.yml
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 enable_certbot_certificate_provisioning: "true"

--- a/demo-idp/group_vars/postgres-hosts.yml
+++ b/demo-idp/group_vars/postgres-hosts.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 provision_postgres: "true"
 ansible_ssh_pipelining: true

--- a/demo-idp/playbook.cleanup.yml
+++ b/demo-idp/playbook.cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Check firewalld package

--- a/demo-idp/playbook.yml
+++ b/demo-idp/playbook.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install thirdparties

--- a/demo-idp/requirements.yml
+++ b/demo-idp/requirements.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 collections:
   - community.docker

--- a/demo-idp/roles/keycloak/defaults/main.yml
+++ b/demo-idp/roles/keycloak/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 keycloak_admin_username: "trentokcadmin"

--- a/demo-idp/roles/keycloak/tasks/cleanup.yml
+++ b/demo-idp/roles/keycloak/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Stop keycloak container

--- a/demo-idp/roles/keycloak/tasks/main.yml
+++ b/demo-idp/roles/keycloak/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install docker

--- a/demo-idp/roles/postgres/defaults/main.yml
+++ b/demo-idp/roles/postgres/defaults/main.yml
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 postgres_install: "true"

--- a/demo-idp/roles/postgres/handlers/main.yml
+++ b/demo-idp/roles/postgres/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Restart postgres

--- a/demo-idp/roles/postgres/tasks/cleanup.yml
+++ b/demo-idp/roles/postgres/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Remove keycloak database

--- a/demo-idp/roles/postgres/tasks/main.yml
+++ b/demo-idp/roles/postgres/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install postgresql

--- a/demo-idp/roles/proxy/defaults/main.yml
+++ b/demo-idp/roles/proxy/defaults/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 proxy_install_nginx: "true"
 proxy_override_nginx_default_conf: "true"

--- a/demo-idp/roles/proxy/handlers/main.yml
+++ b/demo-idp/roles/proxy/handlers/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Restart nginx

--- a/demo-idp/roles/proxy/tasks/cleanup.yml
+++ b/demo-idp/roles/proxy/tasks/cleanup.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Remove nginx vhost file

--- a/demo-idp/roles/proxy/tasks/main.yml
+++ b/demo-idp/roles/proxy/tasks/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install nginx

--- a/demo-idp/roles/proxy/templates/keycloak.conf.j2
+++ b/demo-idp/roles/proxy/templates/keycloak.conf.j2
@@ -1,3 +1,8 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
+
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' close;

--- a/demo-idp/roles/proxy/templates/nginx-default.conf.j2
+++ b/demo-idp/roles/proxy/templates/nginx-default.conf.j2
@@ -1,3 +1,8 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
+
 worker_processes  1;
 
 events {

--- a/demo-idp/roles/proxy/vars/main.yml
+++ b/demo-idp/roles/proxy/vars/main.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 proxy_nginx_conf_base_dir: "/etc/nginx"
 proxy_nginx_vhost_dir: "vhosts.d"

--- a/egeria/.gitignore
+++ b/egeria/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 build
 dist
 egeria

--- a/egeria/Dockerfile
+++ b/egeria/Dockerfile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 FROM opensuse/tumbleweed AS binary-build
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/egeria/Makefile
+++ b/egeria/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 VERSION ?= $(shell ./hack/get_version_from_git.sh)
 INSTALLATIONSOURCE ?= "Community"
 LDFLAGS = -X main.Version="$(VERSION)"

--- a/egeria/ansible/group_vars/egeria-server.yml
+++ b/egeria/ansible/group_vars/egeria-server.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 proxy_nginx_vhost_filename: "egeria"
 proxy_nginx_vhost_http_listen_port: "80"

--- a/egeria/ansible/playbook.yml
+++ b/egeria/ansible/playbook.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # code: language=ansible
 ---
 - name: Install thirdparties

--- a/egeria/ansible/requirements.yml
+++ b/egeria/ansible/requirements.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 ---
 collections:
   - community.docker

--- a/egeria/ansible/templates/egeria.conf.j2
+++ b/egeria/ansible/templates/egeria.conf.j2
@@ -1,3 +1,8 @@
+{#
+SPDX-FileCopyrightText: SUSE LLC
+SPDX-License-Identifier: Apache-2.0
+#}
+
 map $http_upgrade $connection_upgrade {
   default upgrade;
   '' close;

--- a/egeria/cmd/egeria/main.go
+++ b/egeria/cmd/egeria/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/egeria/egeria-fe/.gitignore
+++ b/egeria/egeria-fe/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 # Logs
 logs
 *.log

--- a/egeria/egeria-fe/eslint.config.js
+++ b/egeria/egeria-fe/eslint.config.js
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import js from "@eslint/js";
 import globals from "globals";
 import react from "eslint-plugin-react";

--- a/egeria/egeria-fe/index.html
+++ b/egeria/egeria-fe/index.html
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-FileCopyrightText: SUSE LLC
+  ~ SPDX-License-Identifier: Apache-2.0
+-->
+
 <!doctype html>
 <html lang="en" class="h-full bg-gray-100">
   <head>

--- a/egeria/egeria-fe/postcss.config.js
+++ b/egeria/egeria-fe/postcss.config.js
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 export default {
   plugins: {
     tailwindcss: {},

--- a/egeria/egeria-fe/src/App.jsx
+++ b/egeria/egeria-fe/src/App.jsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useState } from "react";
 import Bar from "./components/Bar";
 import EnvTable from "./components/EnvTable";

--- a/egeria/egeria-fe/src/components/Bar.jsx
+++ b/egeria/egeria-fe/src/components/Bar.jsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import {
   Disclosure,
   DisclosureButton,

--- a/egeria/egeria-fe/src/components/EnvTable.jsx
+++ b/egeria/egeria-fe/src/components/EnvTable.jsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import classNames from "classnames";
 import Pill from "./Pill";
 

--- a/egeria/egeria-fe/src/components/Pill.jsx
+++ b/egeria/egeria-fe/src/components/Pill.jsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import classNames from "classnames";
 
 const sizeClasses = {

--- a/egeria/egeria-fe/src/index.css
+++ b/egeria/egeria-fe/src/index.css
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/egeria/egeria-fe/src/main.jsx
+++ b/egeria/egeria-fe/src/main.jsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";

--- a/egeria/egeria-fe/tailwind.config.js
+++ b/egeria/egeria-fe/tailwind.config.js
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],

--- a/egeria/egeria-fe/vite.config.js
+++ b/egeria/egeria-fe/vite.config.js
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: SUSE LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 

--- a/egeria/go.mod
+++ b/egeria/go.mod
@@ -1,3 +1,8 @@
+<!--
+  ~ SPDX-FileCopyrightText: SUSE LLC
+  ~ SPDX-License-Identifier: Apache-2.0
+-->
+
 module github.com/trento-project/werkzeugoffer/egeria
 
 go 1.23.3

--- a/egeria/hack/get_version_from_git.sh
+++ b/egeria/hack/get_version_from_git.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 TAG=$( git tag | grep -E "[0-9]\.[0-9]\.[0-9]" | sort -rn | head -n1 )
 
 if [ -n "${TAG}" ]; then

--- a/egeria/hack/gh_release_to_obs_changeset.py
+++ b/egeria/hack/gh_release_to_obs_changeset.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 
 import argparse
 import json

--- a/egeria/internal/environment/instance.go
+++ b/egeria/internal/environment/instance.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package environment
 
 import "time"

--- a/egeria/internal/environment/registry.go
+++ b/egeria/internal/environment/registry.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package environment
 
 import (

--- a/egeria/internal/http/common.go
+++ b/egeria/internal/http/common.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package http
 
 import (

--- a/egeria/internal/http/router.go
+++ b/egeria/internal/http/router.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package http
 
 import (

--- a/egeria/internal/http/v1_list_envs_handler.go
+++ b/egeria/internal/http/v1_list_envs_handler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package http
 
 import (

--- a/egeria/packaging/suse/egeria.spec
+++ b/egeria/packaging/suse/egeria.spec
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # spec file for package trento
 #


### PR DESCRIPTION
# Description

In an attempt to follow the REUSE Specification (supported by the Linux Foundation) for managing licence information, this PR adds the recommended `SPDX-FileCopyrightText` and `SPDX-License-Identifier` headers.

Besides, a new linter is added for the CI to check the license headers. 

Related # TRNT-4358

## How was this tested?

License linter, see #4236 